### PR TITLE
user menu not closing on blur

### DIFF
--- a/src/ui/navigation/UserMenu/UserMenu.tsx
+++ b/src/ui/navigation/UserMenu/UserMenu.tsx
@@ -1,19 +1,17 @@
 import { RouteProps } from '@common-types';
-import { useState } from 'react';
+import { HTMLAttributes } from 'react';
 import { FaUserAlt } from 'react-icons/fa';
-import { useClickOutside } from 'src/hooks/useClickOutside';
 import tw, { styled } from 'twin.macro';
 import UserMenuLink from '../UserMenuLink/UserMenuLink';
 import UserMenuLinksGroup from '../UserMenuLinksGroup/UserMenuLinksGroup';
+import { useUserMenuDropDown } from './useUserMenuDropdown';
 
 type Props = {
   className?: string;
 };
 const UserMenu = ({ className }: Props) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const buttonRef = useClickOutside<HTMLButtonElement>(() => setIsOpen(false));
-
-  const handleMenuClick = () => setIsOpen((prev) => !prev);
+  const { isOpen, buttonRef, closeDropdown, openDropdown, toggleDropDown } =
+    useUserMenuDropDown();
 
   return (
     <button
@@ -24,7 +22,7 @@ const UserMenu = ({ className }: Props) => {
       aria-controls="user-menu-menu"
       aria-expanded={isOpen}
       aria-pressed={isOpen}
-      onClick={handleMenuClick}
+      onClick={toggleDropDown}
       tw="flex border text-left relative rounded-full pl-md pr-sm py-sm transition-shadow hover:shadow"
     >
       <span tw="sr-only">Menu</span>
@@ -33,7 +31,7 @@ const UserMenu = ({ className }: Props) => {
 
       <FaUserAlt tw="h-7 w-7 p-xs bg-gray rounded-full text-white ml-md" />
 
-      {isOpen && <Menu />}
+      {isOpen && <Menu onBlur={closeDropdown} onFocus={openDropdown} />}
     </button>
   );
 };
@@ -98,9 +96,11 @@ const links: Record<'preference' | 'dashboard' | 'others', RouteProps[]> = {
   ],
 };
 
-function Menu() {
+type MenuProps = HTMLAttributes<HTMLUListElement>;
+function Menu(props: MenuProps) {
   return (
     <ul
+      {...props}
       id="user-menu-menu"
       role="menu"
       aria-label="Menu links"

--- a/src/ui/navigation/UserMenu/useUserMenuDropdown.ts
+++ b/src/ui/navigation/UserMenu/useUserMenuDropdown.ts
@@ -1,0 +1,25 @@
+import { useCallback, useRef, useState } from 'react';
+import { useClickOutside } from 'src/hooks/useClickOutside';
+
+export const useUserMenuDropDown = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useClickOutside<HTMLButtonElement>(() => setIsOpen(false));
+
+  const blurTimerId = useRef<NodeJS.Timeout>();
+
+  // Give some time to determine if the user is tabbing through the dropdown
+  // or has actually exit the dropdown
+  const closeDropdown = useCallback(() => {
+    blurTimerId.current = setTimeout(() => setIsOpen(false), 50);
+  }, []);
+
+  // Open the dropdown and prevent timed closing
+  const openDropdown = useCallback(() => {
+    blurTimerId.current && clearTimeout(blurTimerId.current);
+    setIsOpen(true);
+  }, []);
+
+  const toggleDropDown = useCallback(() => setIsOpen((prev) => !prev), []);
+
+  return { isOpen, buttonRef, closeDropdown, openDropdown, toggleDropDown };
+};


### PR DESCRIPTION
The dropdown of the navigation bar is not closed when the user exits the list through keyboard tabbing. This PR adds some time gap between the closing and opening of dropdown to decide if the user has actually exited the dropdown or not (tabbing through links inside the dropdown instantly triggers `onBlur`)

This solution is taken from WCAG example. See https://www.w3.org/WAI/tutorials/menus/flyout/#use-parent-as-toggle