### PR TITLE
Fix encoded `x-vercel-ip-city` from vercel header

### DIFF
--- a/src/utils/api/user-ip-locator.ts
+++ b/src/utils/api/user-ip-locator.ts
@@ -1,3 +1,4 @@
+import { tryDecodeQueryParam } from '@utils/string-utils';
 import { NextApiRequest } from 'next';
 import requestIp from 'request-ip';
 
@@ -10,9 +11,9 @@ export type IpAddressInfo = {
 
 const getClientIpInfo = (req: NextApiRequest): IpAddressInfo => ({
   ipAddress: requestIp.getClientIp(req) ?? 'Unknown',
-  ipCountry: req.headers['x-vercel-ip-country']?.toString(),
-  ipCountryRegion: req.headers['x-vercel-ip-country-region']?.toString(),
-  ipCity: req.headers['x-vercel-ip-city']?.toString(),
+  ipCountry: tryDecodeQueryParam(req.headers['x-vercel-ip-country']).decoded,
+  ipCountryRegion: req.headers['x-vercel-ip-country-region']?.toString() ?? '',
+  ipCity: req.headers['x-vercel-ip-city']?.toString() ?? '',
 });
 
 export default getClientIpInfo;

--- a/src/utils/string-utils.ts
+++ b/src/utils/string-utils.ts
@@ -36,3 +36,16 @@ export const isMsAjaxDateString = (dateStr: string) => reMsAjax.test(dateStr);
 
 export const isJsonDateString = (dateStr: string) =>
   isIsoDateString(dateStr) || isMsAjaxDateString(dateStr);
+
+export const tryDecodeQueryParam = (
+  param: string | string[] | undefined
+): { decoded: string; error?: Error } => {
+  if (param === undefined) return { decoded: '' };
+  try {
+    return {
+      decoded: decodeURIComponent(param.toString().replace(/\+/g, ' ')),
+    };
+  } catch (e) {
+    return { decoded: param.toString(), error: e as Error };
+  }
+};


### PR DESCRIPTION
If there're spaces in the ipCity, it looks like this:

![image](https://user-images.githubusercontent.com/54929186/141656678-62273520-5f06-46b5-9b63-f679244dffd0.png)

Also, login logging fails on `dev` because Vercel's headers are not there.