### PR TITLE
feat: sync states between layouts

### DIFF
--- a/@types/common.d.ts
+++ b/@types/common.d.ts
@@ -17,9 +17,6 @@ declare module '@common-types' {
     toggle: () => void;
   };
   type Await<T> = T extends PromiseLike<infer U> ? Await<U> : T;
-  type PageWithLayout = NextPage & {
-    getLayout?: (page: ReactElement) => ReactElement;
-  };
 
   type StyledComponentProps<T> = T extends StyledComponent<
     any,

--- a/@types/next.d.ts
+++ b/@types/next.d.ts
@@ -1,0 +1,45 @@
+declare module '@/next' {
+  import { NextPage } from 'next';
+  import { ReactNode } from 'react';
+
+  type NextPageWithLayout = NextPage & {
+    /**
+     * @description share **layout-level** states between pages
+     *
+     * ## Rule #1
+     * Only states defined in layout or states of component that are imported in layout will be kept
+     *
+     * ```tsx
+     * const Layout = (props) => {
+     *  const [count, setCount] = useState(0); // ✅ This will be kept
+     *
+     *  return (
+     *    <div>
+     *      <Searchbar /> // ✅ State of Searchbar will be kept
+     *      {props.children}
+     *    </div>
+     *  )
+     * }
+     * ```
+     *
+     * ## Rule #2
+     * State are only shared/synced between page with the same exact layout when invoke `getLayout`
+     *
+     * ```tsx
+     * PageA.getLayout = (page) => <Layout1>{page}</Layout1>
+     * PageB.getLayout = (page) => <Layout1>{page}</Layout1> // Sync with PageA
+     * PageC.getLayout = (page) => <Layout1><Layout2>{page}</Layout2></Layout1> // Sync with PageA and PageB
+     * PageD.getLayout = (page) => <Layout1><Layout2>{page}</Layout2></Layout1> // Sync with PageA and PageB and Page C
+     *
+     * const Layout34 = <Layout3><Layout4>{page}</Layout4></Layout3>;
+     * PageE.getLayout = (page) => <Layout3><Layout4>{page}</Layout4></Layout3>
+     * PageF.getLayout = (page) => <Layout34>{page}</Layout34> // Doesn't sync with PageE
+     * PageG.getLayout = (page) => <Layout34>{page}</Layout34> // Sync with PageF only
+     * ```
+     *
+     * ## Rule #3
+     * Layout with `tw` is counted as a different layout
+     */
+    getLayout?(page: ReactNode): ReactNode;
+  };
+}

--- a/@types/next.d.ts
+++ b/@types/next.d.ts
@@ -38,7 +38,8 @@ declare module '@/next' {
      * ```
      *
      * ## Rule #3
-     * Layout with `tw` is counted as a different layout
+     * Layouts with different props are considered as the same layouts and have their states synced with the exception of the `tw` prop.
+     * Same layouts with `tw` props are considered as different layouts.
      */
     getLayout?(page: ReactNode): ReactNode;
   };

--- a/@types/next.d.ts
+++ b/@types/next.d.ts
@@ -2,7 +2,7 @@ declare module '@/next' {
   import { NextPage } from 'next';
   import { ReactNode } from 'react';
 
-  type NextPageWithLayout = NextPage & {
+  type NextLayout<Props = Record<string, unknown>> = NextPage<Props> & {
     /**
      * @description share **layout-level** states between pages
      *
@@ -41,6 +41,10 @@ declare module '@/next' {
      * Layouts with different props are considered as the same layouts and have their states synced with the exception of the `tw` prop.
      * Same layouts with `tw` props are considered as different layouts.
      */
-    getLayout?(page: ReactNode): ReactNode;
+    getLayout(page: ReactNode): ReactNode;
+  };
+
+  type CustomNextPage<Props = Record<string, unknown>> = NextPage<Props> & {
+    getLayout?: NextLayout['getLayout'];
   };
 }

--- a/src/modules/account/layouts/AccountPageLayout/AccountPageLayout.tsx
+++ b/src/modules/account/layouts/AccountPageLayout/AccountPageLayout.tsx
@@ -1,18 +1,17 @@
-import DefaultLayout, {
-  getDefaultLayout,
-} from '@modules/layouts/DefaultLayout';
+import { NextLayout } from '@/next';
+import DefaultLayout from '@modules/layouts/DefaultLayout';
 import AuthGuard from '@modules/user-auth/utils/AuthGuard/AuthGuard';
-import { FC, ReactNode } from 'react';
+import { ReactNode } from 'react';
 
 type AccountPageLayoutProps = {
   className?: string;
   children: ReactNode;
 };
 
-export default function AccountPageLayout({
+const AccountPageLayout: NextLayout<AccountPageLayoutProps> = ({
   className,
   children,
-}: AccountPageLayoutProps) {
+}) => {
   return (
     <AuthGuard promptLogin>
       <div className={className} tw="max-w-5xl mt-xl mx-auto">
@@ -20,9 +19,11 @@ export default function AccountPageLayout({
       </div>
     </AuthGuard>
   );
-}
-
-export const getAccountPageLayout = (page: ReactNode) => {
-  const inner = <AccountPageLayout>{page}</AccountPageLayout>;
-  return getDefaultLayout(inner);
 };
+
+AccountPageLayout.getLayout = (page: ReactNode) => {
+  const inner = <AccountPageLayout>{page}</AccountPageLayout>;
+  return DefaultLayout.getLayout(inner);
+};
+
+export default AccountPageLayout;

--- a/src/modules/account/layouts/AccountPageLayout/AccountPageLayout.tsx
+++ b/src/modules/account/layouts/AccountPageLayout/AccountPageLayout.tsx
@@ -1,22 +1,28 @@
-import DefaultLayout from '@modules/layouts/DefaultLayout';
+import DefaultLayout, {
+  getDefaultLayout,
+} from '@modules/layouts/DefaultLayout';
 import AuthGuard from '@modules/user-auth/utils/AuthGuard/AuthGuard';
-import { FC } from 'react';
+import { FC, ReactNode } from 'react';
 
 type AccountPageLayoutProps = {
   className?: string;
+  children: ReactNode;
 };
 
-const AccountPageLayout: FC<AccountPageLayoutProps> = ({
+export default function AccountPageLayout({
   className,
   children,
-}) => (
-  <DefaultLayout>
+}: AccountPageLayoutProps) {
+  return (
     <AuthGuard promptLogin>
       <div className={className} tw="max-w-5xl mt-xl mx-auto">
         {children}
       </div>
     </AuthGuard>
-  </DefaultLayout>
-);
+  );
+}
 
-export default AccountPageLayout;
+export const getAccountPageLayout = (page: ReactNode) => {
+  const inner = <AccountPageLayout>{page}</AccountPageLayout>;
+  return getDefaultLayout(inner);
+};

--- a/src/modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout.tsx
+++ b/src/modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout.tsx
@@ -9,23 +9,24 @@ type Props = {
 const PaymentSettingPageLayout: NextLayout<PropsWithChildren<Props>> = ({
   className,
   children,
-  ...props
 }) => {
   return (
     <div className={className} tw="">
       <AccountPageHeader title="Payments & payouts" />
 
-      <NextLink href="/account/payments/payment-methods">
-        <a>Payments</a>
-      </NextLink>
+      <ul tw="flex gap-sm">
+        <NextLink href="/account/payments/payment-methods">
+          <a>Payments</a>
+        </NextLink>
 
-      <NextLink href="/account/payments/payout-methods">
-        <a>Payouts</a>
-      </NextLink>
+        <NextLink href="/account/payments/payout-methods">
+          <a>Payouts</a>
+        </NextLink>
 
-      <NextLink href="/account/payments/tax-info">
-        <a>Taxes</a>
-      </NextLink>
+        <NextLink href="/account/payments/tax-info">
+          <a>Taxes</a>
+        </NextLink>
+      </ul>
 
       {children}
     </div>

--- a/src/modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout.tsx
+++ b/src/modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout.tsx
@@ -1,36 +1,40 @@
 import AccountPageHeader from '@modules/account/components/AccountPageHeader/AccountPageHeader';
+import DefaultLayout from '@modules/layouts/DefaultLayout';
 import NextLink from 'next/link';
-import { PropsWithChildren } from 'react';
-import AccountPageLayout from '../AccountPageLayout/AccountPageLayout';
+import { PropsWithChildren, ReactNode } from 'react';
+import AccountPageLayout, {
+  getAccountPageLayout,
+} from '../AccountPageLayout/AccountPageLayout';
 type Props = {
   className?: string;
 };
-function PaymentSettingPageLayout({
+export default function PaymentSettingPageLayout({
   className,
   children,
   ...props
 }: PropsWithChildren<Props>) {
   return (
-    <AccountPageLayout>
-      <div className={className} tw="">
-        <AccountPageHeader title="Payments & payouts" />
+    <div className={className} tw="">
+      <AccountPageHeader title="Payments & payouts" />
 
-        <NextLink href="/account/payments/payment-methods">
-          <a>Payments</a>
-        </NextLink>
+      <NextLink href="/account/payments/payment-methods">
+        <a>Payments</a>
+      </NextLink>
 
-        <NextLink href="/account/payments/payout-methods">
-          <a>Payouts</a>
-        </NextLink>
+      <NextLink href="/account/payments/payout-methods">
+        <a>Payouts</a>
+      </NextLink>
 
-        <NextLink href="/account/payments/tax-info">
-          <a>Taxes</a>
-        </NextLink>
+      <NextLink href="/account/payments/tax-info">
+        <a>Taxes</a>
+      </NextLink>
 
-        {children}
-      </div>
-    </AccountPageLayout>
+      {children}
+    </div>
   );
 }
 
-export default PaymentSettingPageLayout;
+export const getPaymentSettingPageLayout = (page: ReactNode) => {
+  const inner = <PaymentSettingPageLayout>{page}</PaymentSettingPageLayout>;
+  return getAccountPageLayout(inner);
+};

--- a/src/modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout.tsx
+++ b/src/modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout.tsx
@@ -1,18 +1,16 @@
+import { NextLayout } from '@/next';
 import AccountPageHeader from '@modules/account/components/AccountPageHeader/AccountPageHeader';
-import DefaultLayout from '@modules/layouts/DefaultLayout';
 import NextLink from 'next/link';
 import { PropsWithChildren, ReactNode } from 'react';
-import AccountPageLayout, {
-  getAccountPageLayout,
-} from '../AccountPageLayout/AccountPageLayout';
+import AccountPageLayout from '../AccountPageLayout/AccountPageLayout';
 type Props = {
   className?: string;
 };
-export default function PaymentSettingPageLayout({
+const PaymentSettingPageLayout: NextLayout<PropsWithChildren<Props>> = ({
   className,
   children,
   ...props
-}: PropsWithChildren<Props>) {
+}) => {
   return (
     <div className={className} tw="">
       <AccountPageHeader title="Payments & payouts" />
@@ -32,9 +30,11 @@ export default function PaymentSettingPageLayout({
       {children}
     </div>
   );
-}
-
-export const getPaymentSettingPageLayout = (page: ReactNode) => {
-  const inner = <PaymentSettingPageLayout>{page}</PaymentSettingPageLayout>;
-  return getAccountPageLayout(inner);
 };
+
+PaymentSettingPageLayout.getLayout = (page: ReactNode) => {
+  const inner = <PaymentSettingPageLayout>{page}</PaymentSettingPageLayout>;
+  return AccountPageLayout.getLayout(inner);
+};
+
+export default PaymentSettingPageLayout;

--- a/src/modules/layouts/DefaultLayout.tsx
+++ b/src/modules/layouts/DefaultLayout.tsx
@@ -3,15 +3,16 @@ import Layout from './Layout';
 import AppBar from './components/AppBar/AppBar';
 import Footer from './components/Footer/Footer';
 import HomeNavBar from './components/HomeNavBar/HomeNavBar';
+import { NextLayout } from '@/next';
 
 type DefaultLayoutProps = PropsWithChildren<{
   className?: string;
 }>;
 
-export default function DefaultLayout({
+const DefaultLayout: NextLayout<DefaultLayoutProps> = ({
   className,
   children,
-}: DefaultLayoutProps) {
+}) => {
   return (
     <Layout size="sm" tw="flex flex-col min-h-full relative">
       <HomeNavBar tw="hidden lg:block" />
@@ -22,8 +23,10 @@ export default function DefaultLayout({
       <Footer tw="mb-var-app-bar-height lg:mb-0" />
     </Layout>
   );
-}
+};
 
-export const getDefaultLayout = (page: ReactNode) => (
+DefaultLayout.getLayout = (page: ReactNode) => (
   <DefaultLayout>{page}</DefaultLayout>
 );
+
+export default DefaultLayout;

--- a/src/modules/layouts/DefaultLayout.tsx
+++ b/src/modules/layouts/DefaultLayout.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 import Layout from './Layout';
 import AppBar from './components/AppBar/AppBar';
 import Footer from './components/Footer/Footer';
@@ -8,7 +8,10 @@ type DefaultLayoutProps = PropsWithChildren<{
   className?: string;
 }>;
 
-function DefaultLayout({ className, children }: DefaultLayoutProps) {
+export default function DefaultLayout({
+  className,
+  children,
+}: DefaultLayoutProps) {
   return (
     <Layout size="sm" tw="flex flex-col min-h-full relative">
       <HomeNavBar tw="hidden lg:block" />
@@ -21,4 +24,6 @@ function DefaultLayout({ className, children }: DefaultLayoutProps) {
   );
 }
 
-export default DefaultLayout;
+export const getDefaultLayout = (page: ReactNode) => (
+  <DefaultLayout>{page}</DefaultLayout>
+);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,11 +9,10 @@ import '@libs/axios/interceptors';
 import '@reach/dialog/styles.css';
 import 'react-day-picker/lib/style.css';
 import { ModalProvider } from '@ui/Modal/ModalContext';
-import { NextPageWithLayout } from '@/next';
+import { CustomNextPage } from '@/next';
 
-type MyAppProps = {
-  Component: NextPageWithLayout;
-  pageProps: AppProps['pageProps'];
+type MyAppProps = AppProps & {
+  Component: CustomNextPage;
 };
 
 function MyApp({ Component, pageProps }: MyAppProps) {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,4 @@
 import type { AppProps } from 'next/app';
-import { PageWithLayout } from '@common-types';
 import SWRDefaultConfigProvider from '@libs/swr/SWRDefaultConfigProvider';
 import { AuthProvider } from '@modules/user-auth/contexts/AuthContext';
 import GlobalStyle from '@styles/GlobalStyles';
@@ -10,9 +9,10 @@ import '@libs/axios/interceptors';
 import '@reach/dialog/styles.css';
 import 'react-day-picker/lib/style.css';
 import { ModalProvider } from '@ui/Modal/ModalContext';
+import { NextPageWithLayout } from '@/next';
 
 type MyAppProps = {
-  Component: PageWithLayout;
+  Component: NextPageWithLayout;
   pageProps: AppProps['pageProps'];
 };
 

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -1,14 +1,12 @@
+import { NextPageWithLayout } from '@/next';
 import AccountMenu from '@modules/account/components/AccountMenu/AccountMenu';
-import AccountPageLayout, {
-  getAccountPageLayout,
-} from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
+import { getAccountPageLayout } from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
 import { useAuth } from '@modules/user-auth/contexts/AuthContext';
 import { ButtonLink } from '@ui/Button/Button';
 import SeparatorList from '@ui/SeparatorList/SeparatorList';
 import Text from '@ui/Text/Text';
 import useTranslation from 'next-translate/useTranslation';
 import NextLink from 'next/link';
-import React, { ReactNode } from 'react';
 
 export default function AccountIndexPage() {
   const { t } = useTranslation();
@@ -68,4 +66,5 @@ function Header() {
 function Separator() {
   return <div tw="hidden md:(inline font-semibold) ">·</div>;
 }
-AccountIndexPage.getLayout = getAccountPageLayout;
+
+(AccountIndexPage as NextPageWithLayout).getLayout = getAccountPageLayout;

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -1,5 +1,7 @@
 import AccountMenu from '@modules/account/components/AccountMenu/AccountMenu';
-import AccountPageLayout from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
+import AccountPageLayout, {
+  getAccountPageLayout,
+} from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
 import { useAuth } from '@modules/user-auth/contexts/AuthContext';
 import { ButtonLink } from '@ui/Button/Button';
 import SeparatorList from '@ui/SeparatorList/SeparatorList';
@@ -66,6 +68,4 @@ function Header() {
 function Separator() {
   return <div tw="hidden md:(inline font-semibold) ">·</div>;
 }
-AccountIndexPage.getLayout = (page: ReactNode) => {
-  return <AccountPageLayout>{page}</AccountPageLayout>;
-};
+AccountIndexPage.getLayout = getAccountPageLayout;

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -1,6 +1,6 @@
-import { NextPageWithLayout } from '@/next';
+import { CustomNextPage } from '@/next';
 import AccountMenu from '@modules/account/components/AccountMenu/AccountMenu';
-import { getAccountPageLayout } from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
+import AccountPageLayout from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
 import { useAuth } from '@modules/user-auth/contexts/AuthContext';
 import { ButtonLink } from '@ui/Button/Button';
 import SeparatorList from '@ui/SeparatorList/SeparatorList';
@@ -8,7 +8,7 @@ import Text from '@ui/Text/Text';
 import useTranslation from 'next-translate/useTranslation';
 import NextLink from 'next/link';
 
-export default function AccountIndexPage() {
+const AccountIndexPage: CustomNextPage = () => {
   const { t } = useTranslation();
 
   return (
@@ -29,7 +29,7 @@ export default function AccountIndexPage() {
       </div>
     </section>
   );
-}
+};
 
 function Header() {
   const { t } = useTranslation();
@@ -67,4 +67,6 @@ function Separator() {
   return <div tw="hidden md:(inline font-semibold) ">·</div>;
 }
 
-(AccountIndexPage as NextPageWithLayout).getLayout = getAccountPageLayout;
+AccountIndexPage.getLayout = AccountPageLayout.getLayout;
+
+export default AccountIndexPage;

--- a/src/pages/account/payments/payment-methods.tsx
+++ b/src/pages/account/payments/payment-methods.tsx
@@ -1,8 +1,6 @@
-import PaymentSettingPageLayout, {
-  getPaymentSettingPageLayout,
-} from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
+import { NextPageWithLayout } from '@/next';
+import { getPaymentSettingPageLayout } from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 import Text from '@ui/Text/Text';
-import { ReactNode } from 'react';
 
 type Props = {
   className?: string;
@@ -17,4 +15,5 @@ export default function PaymentMethodsPage({ className }: Props) {
   );
 }
 
-PaymentMethodsPage.getLayout = getPaymentSettingPageLayout;
+(PaymentMethodsPage as NextPageWithLayout).getLayout =
+  getPaymentSettingPageLayout;

--- a/src/pages/account/payments/payment-methods.tsx
+++ b/src/pages/account/payments/payment-methods.tsx
@@ -1,11 +1,11 @@
-import { NextPageWithLayout } from '@/next';
-import { getPaymentSettingPageLayout } from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
+import { CustomNextPage } from '@/next';
+import PaymentSettingPageLayout from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 import Text from '@ui/Text/Text';
 
 type Props = {
   className?: string;
 };
-export default function PaymentMethodsPage({ className }: Props) {
+const PaymentMethodsPage: CustomNextPage<Props> = ({ className }) => {
   return (
     <div className={className} tw="">
       <Text component="h2" variant="h3">
@@ -13,7 +13,8 @@ export default function PaymentMethodsPage({ className }: Props) {
       </Text>
     </div>
   );
-}
+};
 
-(PaymentMethodsPage as NextPageWithLayout).getLayout =
-  getPaymentSettingPageLayout;
+PaymentMethodsPage.getLayout = PaymentSettingPageLayout.getLayout;
+
+export default PaymentMethodsPage;

--- a/src/pages/account/payments/payment-methods.tsx
+++ b/src/pages/account/payments/payment-methods.tsx
@@ -1,4 +1,6 @@
-import PaymentSettingPageLayout from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
+import PaymentSettingPageLayout, {
+  getPaymentSettingPageLayout,
+} from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 import Text from '@ui/Text/Text';
 import { ReactNode } from 'react';
 
@@ -15,6 +17,4 @@ export default function PaymentMethodsPage({ className }: Props) {
   );
 }
 
-PaymentMethodsPage.getLayout = (page: ReactNode) => {
-  return <PaymentSettingPageLayout>{page}</PaymentSettingPageLayout>;
-};
+PaymentMethodsPage.getLayout = getPaymentSettingPageLayout;

--- a/src/pages/account/payments/payment-methods.tsx
+++ b/src/pages/account/payments/payment-methods.tsx
@@ -1,13 +1,11 @@
 import { CustomNextPage } from '@/next';
 import PaymentSettingPageLayout from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 import Text from '@ui/Text/Text';
+import { GetStaticProps, InferGetStaticPropsType } from 'next';
 
-type Props = {
-  className?: string;
-};
-const PaymentMethodsPage: CustomNextPage<Props> = ({ className }) => {
+const PaymentMethodsPage: CustomNextPage = () => {
   return (
-    <div className={className} tw="">
+    <div tw="">
       <Text component="h2" variant="h3">
         Payments
       </Text>

--- a/src/pages/account/payments/payout-methods.tsx
+++ b/src/pages/account/payments/payout-methods.tsx
@@ -1,11 +1,11 @@
-import { getPaymentSettingPageLayout } from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 import Text from '@ui/Text/Text';
-import { NextPageWithLayout } from '@/next';
+import { CustomNextPage } from '@/next';
+import PaymentSettingPageLayout from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 
 type Props = {
   className?: string;
 };
-export default function PayoutMethodsPage({ className }: Props) {
+const PayoutMethodsPage: CustomNextPage<Props> = ({ className }) => {
   return (
     <div className={className} tw="">
       <Text component="h2" variant="h3">
@@ -13,7 +13,8 @@ export default function PayoutMethodsPage({ className }: Props) {
       </Text>
     </div>
   );
-}
+};
 
-(PayoutMethodsPage as NextPageWithLayout).getLayout =
-  getPaymentSettingPageLayout;
+PayoutMethodsPage.getLayout = PaymentSettingPageLayout.getLayout;
+
+export default PayoutMethodsPage;

--- a/src/pages/account/payments/payout-methods.tsx
+++ b/src/pages/account/payments/payout-methods.tsx
@@ -1,8 +1,6 @@
-import PaymentSettingPageLayout, {
-  getPaymentSettingPageLayout,
-} from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
+import { getPaymentSettingPageLayout } from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 import Text from '@ui/Text/Text';
-import { ReactNode } from 'react';
+import { NextPageWithLayout } from '@/next';
 
 type Props = {
   className?: string;
@@ -17,4 +15,5 @@ export default function PayoutMethodsPage({ className }: Props) {
   );
 }
 
-PayoutMethodsPage.getLayout = getPaymentSettingPageLayout;
+(PayoutMethodsPage as NextPageWithLayout).getLayout =
+  getPaymentSettingPageLayout;

--- a/src/pages/account/payments/payout-methods.tsx
+++ b/src/pages/account/payments/payout-methods.tsx
@@ -2,12 +2,9 @@ import Text from '@ui/Text/Text';
 import { CustomNextPage } from '@/next';
 import PaymentSettingPageLayout from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 
-type Props = {
-  className?: string;
-};
-const PayoutMethodsPage: CustomNextPage<Props> = ({ className }) => {
+const PayoutMethodsPage: CustomNextPage = () => {
   return (
-    <div className={className} tw="">
+    <div tw="">
       <Text component="h2" variant="h3">
         Payout
       </Text>

--- a/src/pages/account/payments/payout-methods.tsx
+++ b/src/pages/account/payments/payout-methods.tsx
@@ -1,4 +1,6 @@
-import PaymentSettingPageLayout from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
+import PaymentSettingPageLayout, {
+  getPaymentSettingPageLayout,
+} from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 import Text from '@ui/Text/Text';
 import { ReactNode } from 'react';
 
@@ -15,6 +17,4 @@ export default function PayoutMethodsPage({ className }: Props) {
   );
 }
 
-PayoutMethodsPage.getLayout = (page: ReactNode) => {
-  return <PaymentSettingPageLayout>{page}</PaymentSettingPageLayout>;
-};
+PayoutMethodsPage.getLayout = getPaymentSettingPageLayout;

--- a/src/pages/account/payments/tax-info.tsx
+++ b/src/pages/account/payments/tax-info.tsx
@@ -2,12 +2,9 @@ import { CustomNextPage } from '@/next';
 import PaymentSettingPageLayout from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 import Text from '@ui/Text/Text';
 
-type Props = {
-  className?: string;
-};
-const TaxInfoPage: CustomNextPage<Props> = ({ className }: Props) => {
+const TaxInfoPage: CustomNextPage = () => {
   return (
-    <div className={className} tw="">
+    <div tw="">
       <Text component="h2" variant="h3">
         Taxes
       </Text>

--- a/src/pages/account/payments/tax-info.tsx
+++ b/src/pages/account/payments/tax-info.tsx
@@ -1,4 +1,6 @@
-import PaymentSettingPageLayout from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
+import PaymentSettingPageLayout, {
+  getPaymentSettingPageLayout,
+} from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 import Text from '@ui/Text/Text';
 import React, { ReactNode } from 'react';
 
@@ -15,6 +17,4 @@ export default function TaxInfoPage({ className }: Props) {
   );
 }
 
-TaxInfoPage.getLayout = (page: ReactNode) => {
-  return <PaymentSettingPageLayout>{page}</PaymentSettingPageLayout>;
-};
+TaxInfoPage.getLayout = getPaymentSettingPageLayout;

--- a/src/pages/account/payments/tax-info.tsx
+++ b/src/pages/account/payments/tax-info.tsx
@@ -1,11 +1,11 @@
-import { NextPageWithLayout } from '@/next';
-import { getPaymentSettingPageLayout } from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
+import { CustomNextPage } from '@/next';
+import PaymentSettingPageLayout from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 import Text from '@ui/Text/Text';
 
 type Props = {
   className?: string;
 };
-export default function TaxInfoPage({ className }: Props) {
+const TaxInfoPage: CustomNextPage<Props> = ({ className }: Props) => {
   return (
     <div className={className} tw="">
       <Text component="h2" variant="h3">
@@ -13,6 +13,8 @@ export default function TaxInfoPage({ className }: Props) {
       </Text>
     </div>
   );
-}
+};
 
-(TaxInfoPage as NextPageWithLayout).getLayout = getPaymentSettingPageLayout;
+TaxInfoPage.getLayout = PaymentSettingPageLayout.getLayout;
+
+export default TaxInfoPage;

--- a/src/pages/account/payments/tax-info.tsx
+++ b/src/pages/account/payments/tax-info.tsx
@@ -1,8 +1,6 @@
-import PaymentSettingPageLayout, {
-  getPaymentSettingPageLayout,
-} from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
+import { NextPageWithLayout } from '@/next';
+import { getPaymentSettingPageLayout } from '@modules/account/layouts/PaymentSettingPageLayout/PaymentSettingPageLayout';
 import Text from '@ui/Text/Text';
-import React, { ReactNode } from 'react';
 
 type Props = {
   className?: string;
@@ -17,4 +15,4 @@ export default function TaxInfoPage({ className }: Props) {
   );
 }
 
-TaxInfoPage.getLayout = getPaymentSettingPageLayout;
+(TaxInfoPage as NextPageWithLayout).getLayout = getPaymentSettingPageLayout;

--- a/src/pages/account/profile.tsx
+++ b/src/pages/account/profile.tsx
@@ -4,7 +4,7 @@ import { Icon } from '@iconify/react';
 import shieldFill from '@iconify/icons-eva/shield-fill';
 import AccountPageHeader from '@modules/account/components/AccountPageHeader/AccountPageHeader';
 import AccountSettingLayout from '@modules/account/layouts/AccountSettingLayout/AccountSettingLayout';
-import { getAccountPageLayout } from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
+import AccountPageLayout from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
 import AccountInfoCard from '@modules/account/components/AccountInfoCard/AccountInfoCard';
 import AccountInfoCardGroup from '@modules/account/components/AccountInfoCard/AccountInfoCardGroup';
 import ActionFieldGroup from '@modules/account/components/ActionField/ActionFieldGroup';
@@ -13,9 +13,9 @@ import GenderActionField from '@modules/account/components/GenderActionField/Gen
 import DobActionField from '@modules/account/components/DobActionField/DobActionField';
 import { useUserProfile } from '@modules/user-auth/hooks/useUserProfile';
 import LoadingIndicator from '@ui/LoadingIndicator';
-import { NextPageWithLayout } from '@/next';
+import { CustomNextPage } from '@/next';
 
-export default function AccountPersonalInfoPage() {
+const AccountPersonalInfoPage: CustomNextPage = () => {
   const { t } = useTranslation();
 
   return (
@@ -25,7 +25,7 @@ export default function AccountPersonalInfoPage() {
       <AccountSettingLayout main={<Main />} aside={<Aside />} />
     </section>
   );
-}
+};
 
 const Main: VFC = () => {
   const { isProfileReady } = useUserProfile();
@@ -64,5 +64,6 @@ const Aside: VFC = () => {
   );
 };
 
-(AccountPersonalInfoPage as NextPageWithLayout).getLayout =
-  getAccountPageLayout;
+AccountPersonalInfoPage.getLayout = AccountPageLayout.getLayout;
+
+export default AccountPersonalInfoPage;

--- a/src/pages/account/profile.tsx
+++ b/src/pages/account/profile.tsx
@@ -4,7 +4,9 @@ import { Icon } from '@iconify/react';
 import shieldFill from '@iconify/icons-eva/shield-fill';
 import AccountPageHeader from '@modules/account/components/AccountPageHeader/AccountPageHeader';
 import AccountSettingLayout from '@modules/account/layouts/AccountSettingLayout/AccountSettingLayout';
-import AccountPageLayout from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
+import AccountPageLayout, {
+  getAccountPageLayout,
+} from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
 import AccountInfoCard from '@modules/account/components/AccountInfoCard/AccountInfoCard';
 import AccountInfoCardGroup from '@modules/account/components/AccountInfoCard/AccountInfoCardGroup';
 import ActionFieldGroup from '@modules/account/components/ActionField/ActionFieldGroup';
@@ -63,6 +65,4 @@ const Aside: VFC = () => {
   );
 };
 
-AccountPersonalInfoPage.getLayout = (page: ReactNode) => (
-  <AccountPageLayout>{page}</AccountPageLayout>
-);
+AccountPersonalInfoPage.getLayout = getAccountPageLayout;

--- a/src/pages/account/profile.tsx
+++ b/src/pages/account/profile.tsx
@@ -1,12 +1,10 @@
-import React, { ReactNode, VFC } from 'react';
+import React, { VFC } from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import { Icon } from '@iconify/react';
 import shieldFill from '@iconify/icons-eva/shield-fill';
 import AccountPageHeader from '@modules/account/components/AccountPageHeader/AccountPageHeader';
 import AccountSettingLayout from '@modules/account/layouts/AccountSettingLayout/AccountSettingLayout';
-import AccountPageLayout, {
-  getAccountPageLayout,
-} from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
+import { getAccountPageLayout } from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
 import AccountInfoCard from '@modules/account/components/AccountInfoCard/AccountInfoCard';
 import AccountInfoCardGroup from '@modules/account/components/AccountInfoCard/AccountInfoCardGroup';
 import ActionFieldGroup from '@modules/account/components/ActionField/ActionFieldGroup';
@@ -15,6 +13,7 @@ import GenderActionField from '@modules/account/components/GenderActionField/Gen
 import DobActionField from '@modules/account/components/DobActionField/DobActionField';
 import { useUserProfile } from '@modules/user-auth/hooks/useUserProfile';
 import LoadingIndicator from '@ui/LoadingIndicator';
+import { NextPageWithLayout } from '@/next';
 
 export default function AccountPersonalInfoPage() {
   const { t } = useTranslation();
@@ -65,4 +64,5 @@ const Aside: VFC = () => {
   );
 };
 
-AccountPersonalInfoPage.getLayout = getAccountPageLayout;
+(AccountPersonalInfoPage as NextPageWithLayout).getLayout =
+  getAccountPageLayout;

--- a/src/pages/account/security.tsx
+++ b/src/pages/account/security.tsx
@@ -3,7 +3,9 @@ import AccountInfoCardGroup from '@modules/account/components/AccountInfoCard/Ac
 import AccountPageHeader from '@modules/account/components/AccountPageHeader/AccountPageHeader';
 import ActionFieldGroup from '@modules/account/components/ActionField/ActionFieldGroup';
 import PasswordActionField from '@modules/account/components/PasswordActionField/PasswordActionField';
-import AccountPageLayout from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
+import AccountPageLayout, {
+  getAccountPageLayout,
+} from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
 import AccountSettingLayout from '@modules/account/layouts/AccountSettingLayout/AccountSettingLayout';
 import useTranslation from 'next-translate/useTranslation';
 import React, { ReactNode } from 'react';
@@ -60,6 +62,4 @@ function Aside() {
   );
 }
 
-AccountSecurityPage.getLayout = (page: ReactNode) => {
-  return <AccountPageLayout>{page}</AccountPageLayout>;
-};
+AccountSecurityPage.getLayout = getAccountPageLayout;

--- a/src/pages/account/security.tsx
+++ b/src/pages/account/security.tsx
@@ -3,7 +3,6 @@ import AccountInfoCardGroup from '@modules/account/components/AccountInfoCard/Ac
 import AccountPageHeader from '@modules/account/components/AccountPageHeader/AccountPageHeader';
 import ActionFieldGroup from '@modules/account/components/ActionField/ActionFieldGroup';
 import PasswordActionField from '@modules/account/components/PasswordActionField/PasswordActionField';
-import { getAccountPageLayout } from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
 import AccountSettingLayout from '@modules/account/layouts/AccountSettingLayout/AccountSettingLayout';
 import useTranslation from 'next-translate/useTranslation';
 import { Icon } from '@iconify/react';
@@ -13,8 +12,9 @@ import Text from '@ui/Text/Text';
 import { useUserProfile } from '@modules/user-auth/hooks/useUserProfile';
 import LoadingIndicator from '@ui/LoadingIndicator';
 
-import { NextPageWithLayout } from '@/next';
-export default function AccountSecurityPage() {
+import { CustomNextPage } from '@/next';
+import AccountPageLayout from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
+const AccountSecurityPage: CustomNextPage = () => {
   const { t } = useTranslation();
 
   return (
@@ -24,7 +24,7 @@ export default function AccountSecurityPage() {
       <AccountSettingLayout main={<Main />} aside={<Aside />} />
     </section>
   );
-}
+};
 
 function Main() {
   const { t } = useTranslation();
@@ -60,4 +60,6 @@ function Aside() {
   );
 }
 
-(AccountSecurityPage as NextPageWithLayout).getLayout = getAccountPageLayout;
+AccountSecurityPage.getLayout = AccountPageLayout.getLayout;
+
+export default AccountSecurityPage;

--- a/src/pages/account/security.tsx
+++ b/src/pages/account/security.tsx
@@ -3,12 +3,9 @@ import AccountInfoCardGroup from '@modules/account/components/AccountInfoCard/Ac
 import AccountPageHeader from '@modules/account/components/AccountPageHeader/AccountPageHeader';
 import ActionFieldGroup from '@modules/account/components/ActionField/ActionFieldGroup';
 import PasswordActionField from '@modules/account/components/PasswordActionField/PasswordActionField';
-import AccountPageLayout, {
-  getAccountPageLayout,
-} from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
+import { getAccountPageLayout } from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
 import AccountSettingLayout from '@modules/account/layouts/AccountSettingLayout/AccountSettingLayout';
 import useTranslation from 'next-translate/useTranslation';
-import React, { ReactNode } from 'react';
 import { Icon } from '@iconify/react';
 import shieldFill from '@iconify/icons-eva/shield-fill';
 import EmailActionField from '@modules/account/components/EmailActionField/EmailActionField';
@@ -16,6 +13,7 @@ import Text from '@ui/Text/Text';
 import { useUserProfile } from '@modules/user-auth/hooks/useUserProfile';
 import LoadingIndicator from '@ui/LoadingIndicator';
 
+import { NextPageWithLayout } from '@/next';
 export default function AccountSecurityPage() {
   const { t } = useTranslation();
 
@@ -62,4 +60,4 @@ function Aside() {
   );
 }
 
-AccountSecurityPage.getLayout = getAccountPageLayout;
+(AccountSecurityPage as NextPageWithLayout).getLayout = getAccountPageLayout;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,8 +1,11 @@
-import { getDefaultLayout } from '@modules/layouts/DefaultLayout';
+import { CustomNextPage } from '@/next';
+import DefaultLayout from '@modules/layouts/DefaultLayout';
 import React from 'react';
 
-export default function HomePage() {
+const HomePage: CustomNextPage = () => {
   return <></>;
-}
+};
 
-HomePage.getLayout = getDefaultLayout;
+HomePage.getLayout = DefaultLayout.getLayout;
+
+export default HomePage;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,8 @@
-import DefaultLayout from '@modules/layouts/DefaultLayout';
-import React, { ReactNode } from 'react';
+import { getDefaultLayout } from '@modules/layouts/DefaultLayout';
+import React from 'react';
 
 export default function HomePage() {
   return <></>;
 }
 
-HomePage.getLayout = (page: ReactNode) => {
-  return <DefaultLayout>{page}</DefaultLayout>;
-};
+HomePage.getLayout = getDefaultLayout;


### PR DESCRIPTION
### Description

Currently, if you enter something in the search bar and go to another page, the input will be reset. This is because Next.js doesn't recognize the nested layout as the same layout, so it doesn't do proper reconciliation.

Video shows fixed version.

https://www.awesomescreenshot.com/video/6012782?key=be957f01eb589a6bab38a61015fdd93c