### PR TITLE
fix(ui): snackbar sticks to right side (#114)

### DIFF
--- a/src/pages/docs/snackbar.tsx
+++ b/src/pages/docs/snackbar.tsx
@@ -51,7 +51,11 @@ export default function SnackbarDocsPage() {
         </ButtonPrimary>
         <ButtonPrimary
           size="md"
-          onClick={() => showSnackError(new Date().toISOString())}
+          onClick={() =>
+            showSnackError(
+              'Lorem ipsum dolor, sit amet consectetur adipisicing elit. Ad nostrum sint minus consectetur nam exercitationem eius reiciendis voluptatibus aliquam repudiandae!'
+            )
+          }
         >
           Enqueue Error
         </ButtonPrimary>

--- a/src/ui/Snackbar/Snackbar.tsx
+++ b/src/ui/Snackbar/Snackbar.tsx
@@ -12,12 +12,27 @@ import Text from '@ui/Text/Text';
 import { IconButtonGhost } from '@ui/IconButton/IconButton';
 
 type Props = {
+  /**
+   * Classname to merge styles
+   */
   className?: string;
+  /**
+   * Title text (not the title attribute)
+   */
   title?: ReactNode;
+  /**
+   * Color theme
+   */
   severity: StyledIconContainerProps['severity'];
+  /**
+   * Body text
+   */
   message: ReactNode;
   onDismiss(): void;
 };
+/**
+ * Uses for showing/alerting a short message
+ */
 function Snackbar({ className, severity = 'default', ...props }: Props) {
   return (
     <StyledContainer type="assertive" className={className}>
@@ -44,7 +59,6 @@ function Snackbar({ className, severity = 'default', ...props }: Props) {
 }
 
 const StyledContainer = styled(ReachAlert)`
-  width: min(100%, 20rem);
   ${tw`flex items-center gap-md text-body2`}
   ${tw`rounded-lg bg-white`}
   ${tw`shadow-z8 p-md`}
@@ -54,7 +68,13 @@ const StyledContainer = styled(ReachAlert)`
 /*                             ANCHOR: SNACKBAR ICON                          */
 /* -------------------------------------------------------------------------- */
 type SnackbarIconProps = {
+  /**
+   * Classname to merge styles
+   */
   className?: string;
+  /**
+   * Color theme
+   */
   severity: StyledIconContainerProps['severity'];
 };
 function SnackbarIcon(props: SnackbarIconProps) {
@@ -97,6 +117,9 @@ const StyledIconContainer = styled.span<StyledIconContainerProps>`
   ${tw`w-10 h-10 flex items-center justify-center  self-start rounded-xl`}
 `;
 
+/**
+ * Returns color theme base on severity
+ */
 const styleSeverity = (severity: StyledIconContainerProps['severity']) => {
   switch (severity) {
     case 'error':

--- a/src/ui/Snackbar/SnackbarGroup.tsx
+++ b/src/ui/Snackbar/SnackbarGroup.tsx
@@ -11,12 +11,21 @@ type TSnackbar = ComponentProps<typeof Snackbar> & {
   id: string;
 };
 type Props = {
+  /**
+   * Classname for merging styles
+   */
   className?: string;
+  /**
+   * Snackbars information to render
+   */
   snacks: TSnackbar[];
 };
+/**
+ * Uses for grouping \<Snackbar />
+ */
 function SnackbarGroup({ className, ...props }: Props) {
   return (
-    <ol className={className} tw="flex flex-col gap-sm">
+    <ol className={className} tw="flex flex-col gap-sm w-[min(100%, 20rem)]">
       <AnimateSharedLayout>
         <AnimatePresence>
           {props.snacks.map((snackbarProps) => (


### PR DESCRIPTION
Fixes: #114

The problem is a weird bug with `width: min(100%, 20rem)`.
Solve it by moving the width constraint to the SnackbarGroup.
It makes more sense anyway, individual Snackbar should not worry
about where it is used.

Also add missing comments and update the example with long text.

![image](https://user-images.githubusercontent.com/52666982/143184903-c4239d91-bf6c-4c8e-9c40-7dd5f2269f58.png)
