### PR TITLE
Refactor: `Button` and `Link`

### DIFF
--- a/@types/common.d.ts
+++ b/@types/common.d.ts
@@ -16,15 +16,6 @@ declare module '@common-types' {
   };
   type Await<T> = T extends PromiseLike<infer U> ? Await<U> : T;
 
-  type StyledComponentProps<T> = T extends StyledComponent<
-    any,
-    any,
-    infer P,
-    any
-  >
-    ? P
-    : never;
-
   type Type<T> = {
     new (...args: any[]): T;
   };

--- a/src/modules/account/components/ActionField/ActionFieldButton.tsx
+++ b/src/modules/account/components/ActionField/ActionFieldButton.tsx
@@ -1,12 +1,12 @@
-import { StyledComponentProps } from '@common-types';
-import { ButtonGhost } from '@ui/Button';
+import { Button } from '@ui/Button';
+import { ButtonBaseProps } from '@ui/Button/styles';
 import tw, { styled } from 'twin.macro';
 
-type ButtonProps = StyledComponentProps<typeof ButtonGhost>;
-const attrs: ButtonProps = {
+const attrs: ButtonBaseProps = {
+  variant: 'ghost',
   size: 'sm',
 };
-const ActionFieldButton = styled(ButtonGhost).attrs(attrs)`
+const ActionFieldButton = styled(Button).attrs(attrs)`
   ${tw`text-secondary font-semibold`}
 `;
 

--- a/src/modules/account/components/ChangeDobForm/ChangeDobForm.tsx
+++ b/src/modules/account/components/ChangeDobForm/ChangeDobForm.tsx
@@ -1,10 +1,10 @@
+import { VFC } from 'react';
+import useTranslation from 'next-translate/useTranslation';
 import Form from '@ui/Form/Form';
 import DateField from '@ui/Form/DateField';
-import { ButtonSecondary } from '@ui/Button';
-import useTranslation from 'next-translate/useTranslation';
-import { VFC } from 'react';
-import useChangeDobForm from './useChangeDobForm';
+import { Button } from '@ui/Button';
 import { MAXIMUM_DOB } from '@models/constnats';
+import useChangeDobForm from './useChangeDobForm';
 
 const ChangeDobForm: VFC = () => {
   const { t } = useTranslation();
@@ -18,13 +18,14 @@ const ChangeDobForm: VFC = () => {
         inputProps={{ 'auto-capitalize': 'words', autoComplete: 'bday' }}
       />
 
-      <ButtonSecondary
+      <Button
         type="submit"
+        variant="secondary"
         size="lg"
         disabled={form.formState.isSubmitting}
       >
         {t('account:personal-info.change-gender.submit-button')}
-      </ButtonSecondary>
+      </Button>
     </Form>
   );
 };

--- a/src/modules/account/components/ChangeFullNameForm/ChangeFullNameForm.tsx
+++ b/src/modules/account/components/ChangeFullNameForm/ChangeFullNameForm.tsx
@@ -1,6 +1,6 @@
+import { Button } from '@ui/Button';
 import Form from '@ui/Form/Form';
 import TextField from '@ui/Form/TextField';
-import { ButtonSecondary } from '@ui/Button';
 import { InputRow } from '@ui/Row/Row';
 import Text from '@ui/Text/Text';
 import useTranslation from 'next-translate/useTranslation';
@@ -32,13 +32,14 @@ const ChangeFullNameForm: VFC = () => {
         />
       </InputRow>
 
-      <ButtonSecondary
+      <Button
         type="submit"
         size="lg"
+        variant="secondary"
         disabled={form.formState.isSubmitting}
       >
         {t('account:personal-info.change-name.submit-button')}
-      </ButtonSecondary>
+      </Button>
     </Form>
   );
 };

--- a/src/modules/account/components/ChangeGenderForm/ChangeGenderForm.tsx
+++ b/src/modules/account/components/ChangeGenderForm/ChangeGenderForm.tsx
@@ -1,10 +1,10 @@
-import Form from '@ui/Form/Form';
-import { ButtonSecondary } from '@ui/Button';
-import useTranslation from 'next-translate/useTranslation';
 import { VFC } from 'react';
-import useChangeGenderForm from './useChangeGenderForm';
+import useTranslation from 'next-translate/useTranslation';
+import { Button } from '@ui/Button';
+import Form from '@ui/Form/Form';
 import Select from '@ui/Form/Select';
 import { GENDERS } from '@models/constnats';
+import useChangeGenderForm from './useChangeGenderForm';
 
 const ChangeGenderForm: VFC = () => {
   const { t } = useTranslation();
@@ -24,13 +24,14 @@ const ChangeGenderForm: VFC = () => {
         ))}
       </Select>
 
-      <ButtonSecondary
+      <Button
         type="submit"
         size="lg"
+        variant="secondary"
         disabled={form.formState.isSubmitting}
       >
         {t('account:personal-info.change-gender.submit-button')}
-      </ButtonSecondary>
+      </Button>
     </Form>
   );
 };

--- a/src/modules/account/components/ChangePasswordForm/ChangePasswordForm.tsx
+++ b/src/modules/account/components/ChangePasswordForm/ChangePasswordForm.tsx
@@ -1,5 +1,5 @@
 import { useAuth } from '@modules/user-auth/contexts/AuthContext';
-import { ButtonSecondary } from '@ui/Button';
+import { Button } from '@ui/Button';
 import Form from '@ui/Form/Form';
 import HiddenField from '@ui/Form/HiddenField';
 import PasswordField from '@ui/Form/PasswordField';
@@ -44,13 +44,14 @@ function ChangePasswordForm() {
         autoComplete="new-password"
       />
 
-      <ButtonSecondary
+      <Button
         type="submit"
         size="lg"
+        variant="secondary"
         disabled={form.formState.isSubmitting}
       >
         {t('account:security.change-password.submit-button')}
-      </ButtonSecondary>
+      </Button>
     </Form>
   );
 }

--- a/src/modules/account/components/ForgetPasswordButton/ForgetPasswordButton.tsx
+++ b/src/modules/account/components/ForgetPasswordButton/ForgetPasswordButton.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from 'react';
 import useTranslation from 'next-translate/useTranslation';
-import { ButtonProps, ButtonLink } from '@ui/Button';
+import { ButtonProps, Button } from '@ui/Button';
 import { useModals } from '@ui/Modal/ModalContext';
 
 type ForgetPasswordButtonProps = ButtonProps;
@@ -13,9 +13,14 @@ const ForgetPasswordButton = forwardRef<
   const { forgetPasswordModal } = useModals();
 
   return (
-    <ButtonLink {...props} ref={ref} onClick={forgetPasswordModal.show}>
+    <Button
+      {...props}
+      variant="link"
+      ref={ref}
+      onClick={forgetPasswordModal.show}
+    >
       {t('account:security.forget-password.button')}
-    </ButtonLink>
+    </Button>
   );
 });
 

--- a/src/modules/account/components/PasswordActionField/PasswordActionField.tsx
+++ b/src/modules/account/components/PasswordActionField/PasswordActionField.tsx
@@ -6,7 +6,6 @@ import ChangePasswordForm from '../ChangePasswordForm/ChangePasswordForm';
 import { useAuth } from '@modules/user-auth/contexts/AuthContext';
 import useUserProfile from '@modules/user-auth/hooks/useUserProfile';
 import Text from '@ui/Text/Text';
-import { ButtonLink } from '@ui/Button';
 import ForgetPasswordButton from '../ForgetPasswordButton/ForgetPasswordButton';
 
 const PasswordActionField: VFC = () => {

--- a/src/modules/account/components/SendEmailVerificationButton/SendEmailVerificationButton.tsx
+++ b/src/modules/account/components/SendEmailVerificationButton/SendEmailVerificationButton.tsx
@@ -3,7 +3,7 @@ import useTranslation from 'next-translate/useTranslation';
 import { useSnackbar } from '@ui/Snackbar/SnackbarContext';
 import { getErrorMessage } from '@utils/api-responses';
 import AuthApi from '@services/AuthApi';
-import { ButtonProps, ButtonLink } from '@ui/Button';
+import { ButtonProps, Button } from '@ui/Button';
 
 type SendEmailVerificationButtonProps = ButtonProps & {
   disableAfterClickMs?: number;
@@ -48,8 +48,9 @@ const SendEmailVerificationButton = forwardRef<
   };
 
   return (
-    <ButtonLink
+    <Button
       {...props}
+      variant="link"
       onClick={onClick}
       disabled={disabled || internalDisableCountdown > 0}
       ref={ref}
@@ -59,7 +60,7 @@ const SendEmailVerificationButton = forwardRef<
         ` (${t('account:security.verify-email.message.retry', {
           retryCountdown: internalDisableCountdown / 1000,
         })})`}
-    </ButtonLink>
+    </Button>
   );
 });
 

--- a/src/modules/layouts/components/HomeNavBar/HomeNavBar.tsx
+++ b/src/modules/layouts/components/HomeNavBar/HomeNavBar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { LinkBase } from '@ui/Button/Link';
-import { ButtonPrimary } from '@ui/Button';
+import { Link } from '@ui/Button/Link';
 import { useModals } from '@ui/Modal/ModalContext';
 import LogoWithName from '@ui/Logo/LogoWithName';
 import LocationSearchBar from '@ui/LocationSearchBar/LocationSearchBar';
@@ -8,6 +7,7 @@ import Layout from '@modules/layouts/Layout';
 import { useAuth } from '@modules/user-auth/contexts/AuthContext';
 import UserMenu from '../UserMenu/UserMenu';
 import LanguageMenu from '../LanguageMenu/LanguageMenu';
+import { Button } from '@ui/Button';
 
 type Props = {
   className?: string;
@@ -19,22 +19,23 @@ const HomeNavBar = ({ className }: Props) => {
   return (
     <header className={className} tw="z-10 bg-white py-lg shadow">
       <Layout.Container tw="flex items-center justify-between">
-        <LinkBase href="/">
+        <Link href="/">
           <LogoWithName />
-        </LinkBase>
+        </Link>
 
         <LocationSearchBar tw="min-w-[20rem]" />
 
         <nav aria-label="Main" tw="flex items-center gap-md">
           {!isAuthenticated && (
-            <ButtonPrimary
+            <Button
               onClick={registerModal?.show}
               rounded
+              variant="primary"
               size="md"
               tw="font-semibold mr-md"
             >
               Join our community
-            </ButtonPrimary>
+            </Button>
           )}
 
           <LanguageMenu />

--- a/src/modules/layouts/components/LanguageMenu/LanguageMenu.tsx
+++ b/src/modules/layouts/components/LanguageMenu/LanguageMenu.tsx
@@ -3,12 +3,12 @@ import useTranslation from 'next-translate/useTranslation';
 import setLanguage from 'next-translate/setLanguage';
 import { Icon } from '@iconify/react';
 import globeFill from '@iconify/icons-eva/globe-fill';
-import { ButtonOutline } from '@ui/Button';
 import { Menu, MenuItem, MenuItemGroup } from '@ui/Menu';
 import Text from '@ui/Text/Text';
 import i18nConfig from 'i18n.json';
 import CountryFlagIcon from '@ui/CountryFlagIcon';
 import { getCountryCodeByLocale, Locale } from '@utils/locale-utils';
+import { Button } from '@ui/Button';
 
 const LanguageMenu: VFC = () => {
   const { t, lang } = useTranslation();
@@ -45,10 +45,11 @@ const LanguageMenuButton = forwardRef<
 >((props, ref) => {
   const { lang } = useTranslation();
   return (
-    <ButtonOutline
+    <Button
       {...props}
       icon
       size="lg"
+      variant="outline"
       tw="relative border p-xs transition-shadow hover:shadow"
       ref={ref}
     >
@@ -64,6 +65,6 @@ const LanguageMenuButton = forwardRef<
       >
         <Icon icon={globeFill} height={20} width={20} />
       </span>
-    </ButtonOutline>
+    </Button>
   );
 });

--- a/src/modules/layouts/components/UserMenu/UserMenu.tsx
+++ b/src/modules/layouts/components/UserMenu/UserMenu.tsx
@@ -4,7 +4,7 @@ import useTranslation from 'next-translate/useTranslation';
 import { Icon } from '@iconify/react';
 import personFill from '@iconify/icons-eva/person-fill';
 import menuFill from '@iconify/icons-eva/menu-fill';
-import { ButtonGhost } from '@ui/Button';
+import { Button } from '@ui/Button';
 import { useModals } from '@ui/Modal/ModalContext';
 import { Menu, MenuItem, MenuItemGroup, MenuLink } from '@ui/Menu';
 import { useAuth } from '@modules/user-auth/contexts/AuthContext';
@@ -71,17 +71,18 @@ const UserMenu: VFC = () => {
 const UserMenuButton = forwardRef<HTMLButtonElement, ComponentProps<'button'>>(
   (props, ref) => {
     return (
-      <ButtonGhost
+      <Button
         {...props}
         rounded
         size="md"
+        variant="ghost"
         tw="flex items-center border pr-sm transition-shadow hover:shadow"
         ref={ref}
       >
         <Icon icon={menuFill} height={24} />
         <Icon icon={personFill} height={32} width={32} tw="p-xs ml-xs" />
         <span tw="sr-only">User menu</span>
-      </ButtonGhost>
+      </Button>
     );
   }
 );

--- a/src/modules/user-auth/components/ForgetPasswordForm/ForgetPasswordForm.tsx
+++ b/src/modules/user-auth/components/ForgetPasswordForm/ForgetPasswordForm.tsx
@@ -1,11 +1,11 @@
 import { Icon } from '@iconify/react';
 import closeCircleFill from '@iconify/icons-eva/close-circle-fill';
-import { ButtonPrimary } from '@ui/Button';
 import Form from '@ui/Form/Form';
 import TextField from '@ui/Form/TextField';
 import Text from '@ui/Text/Text';
 import useTranslation from 'next-translate/useTranslation';
 import useForgetPasswordForm from './useForgetPasswordForm';
+import { Button } from '@ui/Button';
 
 const ForgetPasswordForm = () => {
   const { form, onSubmit, submitError } = useForgetPasswordForm();
@@ -37,16 +37,17 @@ const ForgetPasswordForm = () => {
         )}
       </div>
 
-      <ButtonPrimary
-        size="md"
+      <Button
         type="submit"
+        size="md"
+        variant="primary"
         tw="block w-full"
         disabled={form.formState.isSubmitting}
       >
         {form.formState.isSubmitting
           ? t('common:forgetPassword.submitButton.loading')
           : t('common:forgetPassword.submitButton.submit')}
-      </ButtonPrimary>
+      </Button>
     </Form>
   );
 };

--- a/src/modules/user-auth/components/LoginForm/LoginForm.tsx
+++ b/src/modules/user-auth/components/LoginForm/LoginForm.tsx
@@ -3,7 +3,6 @@ import facebookIcon from '@iconify/icons-logos/facebook';
 import googleIcon from '@iconify/icons-logos/google-icon';
 import closeCircleFill from '@iconify/icons-eva/close-circle-fill';
 import { useModals } from '@ui/Modal/ModalContext';
-import { ButtonLink, ButtonOutline, ButtonPrimary } from '@ui/Button';
 import Checkbox from '@ui/Form/Checkbox';
 import Form from '@ui/Form/Form';
 import PasswordField from '@ui/Form/PasswordField';
@@ -15,6 +14,7 @@ import { ButtonHTMLAttributes, ReactNode } from 'react';
 import tw from 'twin.macro';
 import useLoginForm from './useLoginForm';
 import Logo from '@ui/Logo/Logo';
+import { Button } from '@ui/Button';
 
 const LoginForm = () => {
   const {
@@ -45,9 +45,13 @@ const LoginForm = () => {
         name="password"
         autoComplete="current-password"
         inputDescription={
-          <ButtonLink type="button" onClick={forgetPasswordModal.show}>
+          <Button
+            type="button"
+            variant="link"
+            onClick={forgetPasswordModal.show}
+          >
             {t('common:login.forgetPassword')}
-          </ButtonLink>
+          </Button>
         }
       />
 
@@ -64,16 +68,17 @@ const LoginForm = () => {
         </Form.ErrorMessage>
       )}
 
-      <ButtonPrimary
-        size="md"
+      <Button
         type="submit"
+        size="md"
+        variant="primary"
         tw="block w-full"
         disabled={form.formState.isSubmitting}
       >
         {form.formState.isSubmitting
           ? t('common:login.submitButton.loading')
           : t('common:login.submitButton.submit')}
-      </ButtonPrimary>
+      </Button>
 
       <HrText tw="my-lg">{t('common:login.or')}</HrText>
 
@@ -127,13 +132,14 @@ function SignInExternalButton({
   ...buttonProps
 }: SignInExternalButtonProps) {
   return (
-    <ButtonOutline
+    <Button
       tw="w-full grid grid-cols-[3rem auto] place-items-center"
       size="md"
+      variant="outline"
       {...buttonProps}
     >
       <span aria-hidden>{icon}</span>
       <span tw="text-left">{text}</span>
-    </ButtonOutline>
+    </Button>
   );
 }

--- a/src/modules/user-auth/components/RegisterForm/RegisterForm.tsx
+++ b/src/modules/user-auth/components/RegisterForm/RegisterForm.tsx
@@ -1,5 +1,4 @@
 import DateField from '@ui/Form/DateField';
-import { ButtonLink, ButtonPrimary } from '@ui/Button';
 import { GENDERS, MAXIMUM_DOB } from '@models/constnats';
 import Form from '@ui/Form/Form';
 import PasswordField from '@ui/Form/PasswordField';
@@ -13,6 +12,7 @@ import useRegisterForm from './useRegisterForm';
 import { useModals } from '@ui/Modal/ModalContext';
 import { Icon } from '@iconify/react';
 import closeCircleFill from '@iconify/icons-eva/close-circle-fill';
+import { Button } from '@ui/Button';
 
 const RegisterForm = () => {
   const { form, onSubmit, submitError, passwordValidationResults } =
@@ -27,9 +27,9 @@ const RegisterForm = () => {
           {t('common:register.welcome')}
         </Text>
 
-        <ButtonLink type="button" onClick={loginModal.show}>
+        <Button type="button" variant="link" onClick={loginModal.show}>
           {t('common:register.alreadyHasAccount')}
-        </ButtonLink>
+        </Button>
       </div>
 
       <InputRow>
@@ -104,16 +104,17 @@ const RegisterForm = () => {
         </Form.ErrorMessage>
       )}
 
-      <ButtonPrimary
-        size="md"
+      <Button
         type="submit"
+        size="md"
+        variant="primary"
         tw="block w-full mt-md"
         disabled={form.formState.isSubmitting}
       >
         {form.formState.isSubmitting
           ? t('common:register.submitButton.loading')
           : t('common:register.submitButton.submit')}
-      </ButtonPrimary>
+      </Button>
     </Form>
   );
 };

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -2,8 +2,8 @@ import { CustomNextPage } from '@/next';
 import AccountMenu from '@modules/account/components/AccountMenu/AccountMenu';
 import AccountPageLayout from '@modules/account/layouts/AccountPageLayout/AccountPageLayout';
 import { useAuth } from '@modules/user-auth/contexts/AuthContext';
-import { ButtonLink } from '@ui/Button';
-import { LinkSimple } from '@ui/Button/Link';
+import { Button } from '@ui/Button';
+import { Link } from '@ui/Button/Link';
 import SeparatorList from '@ui/SeparatorList/SeparatorList';
 import Text from '@ui/Text/Text';
 import useTranslation from 'next-translate/useTranslation';
@@ -22,9 +22,9 @@ const AccountIndexPage: CustomNextPage = () => {
       <div tw="text-center">
         <p>{t('account:index.deactivate.title')}</p>
 
-        <ButtonLink tw="font-semibold">
+        <Button variant="link" tw="font-semibold">
           {t('account:index.deactivate.button')}
-        </ButtonLink>
+        </Button>
       </div>
     </section>
   );
@@ -52,9 +52,9 @@ function Header() {
           {user?.email}
         </div>
 
-        <LinkSimple href="/account/profile" tw="font-semibold">
+        <Link variant="link" href="/account/profile" tw="font-semibold">
           {t('account:index.go-to-profile')}
-        </LinkSimple>
+        </Link>
       </SeparatorList>
     </header>
   );

--- a/src/pages/docs/button-and-link.tsx
+++ b/src/pages/docs/button-and-link.tsx
@@ -1,19 +1,7 @@
 import DocsLayout from '@modules/layouts/DocsLayout';
 import Text from '@ui/Text/Text';
-import {
-  ButtonGhost,
-  ButtonLink,
-  ButtonOutline,
-  ButtonPrimary,
-  ButtonSecondary,
-} from '@ui/Button';
-import {
-  LinkSimple,
-  LinkPrimary,
-  LinkSecondary,
-  LinkOutline,
-  LinkGhost,
-} from '@ui/Button/Link';
+import { Button } from '@ui/Button';
+import { Link } from '@ui/Button/Link';
 import { CustomNextPage } from '@/next';
 
 const ButtonAndLinkDocsPage: CustomNextPage = () => {
@@ -36,29 +24,29 @@ const ButtonDocs = () => (
     </Text>
     <div tw="space-y-2">
       <div>
-        <ButtonPrimary tw="w-32" size="md">
+        <Button variant="primary" tw="w-32" size="md">
           Primary
-        </ButtonPrimary>
+        </Button>
       </div>
       <div>
-        <ButtonSecondary tw="w-32" size="md">
+        <Button variant="secondary" tw="w-32" size="md">
           Secondary
-        </ButtonSecondary>
+        </Button>
       </div>
       <div>
-        <ButtonOutline tw="w-32" size="md">
+        <Button variant="outline" tw="w-32" size="md">
           Outline
-        </ButtonOutline>
+        </Button>
       </div>
       <div>
-        <ButtonGhost tw="w-32" size="md">
+        <Button variant="ghost" tw="w-32" size="md">
           Ghost
-        </ButtonGhost>
+        </Button>
       </div>
       <div>
-        <ButtonLink tw="w-32" size="md">
+        <Button variant="link" tw="w-32" size="md">
           Link
-        </ButtonLink>
+        </Button>
       </div>
     </div>
   </div>
@@ -71,29 +59,29 @@ const LinkDocs = () => (
     </Text>
     <div tw="space-y-2">
       <div>
-        <LinkPrimary href="/" tw="w-32" size="md">
+        <Link variant="primary" href="/" tw="w-32" size="md">
           Primary
-        </LinkPrimary>
+        </Link>
       </div>
       <div>
-        <LinkSecondary href="/" tw="w-32" size="md">
+        <Link variant="secondary" href="/" tw="w-32" size="md">
           Secondary
-        </LinkSecondary>
+        </Link>
       </div>
       <div>
-        <LinkOutline href="/" tw="w-32" size="md">
+        <Link variant="outline" href="/" tw="w-32" size="md">
           Outline
-        </LinkOutline>
+        </Link>
       </div>
       <div>
-        <LinkGhost href="/" tw="w-32" size="md">
+        <Link variant="ghost" href="/" tw="w-32" size="md">
           Ghost
-        </LinkGhost>
+        </Link>
       </div>
       <div>
-        <LinkSimple href="/" tw="w-32" size="md">
-          Simple
-        </LinkSimple>
+        <Link variant="link" href="/" tw="w-32" size="md">
+          Link
+        </Link>
       </div>
     </div>
   </div>

--- a/src/pages/docs/snackbar.tsx
+++ b/src/pages/docs/snackbar.tsx
@@ -1,6 +1,6 @@
 import DocsLayout from '@modules/layouts/DocsLayout';
 import { useSnackbar } from '@ui/Snackbar/SnackbarContext';
-import { ButtonPrimary } from '@ui/Button';
+import { Button } from '@ui/Button';
 import Snackbar from '@ui/Snackbar/Snackbar';
 import { CustomNextPage } from '@/next';
 
@@ -43,14 +43,16 @@ const SnackbarDocsPage: CustomNextPage = () => {
       </div>
 
       <div tw="mt-lg space-x-md">
-        <ButtonPrimary
+        <Button
           size="md"
+          variant="primary"
           onClick={() => showSnackSuccess(new Date().toISOString())}
         >
           Enqueue Success
-        </ButtonPrimary>
-        <ButtonPrimary
+        </Button>
+        <Button
           size="md"
+          variant="primary"
           onClick={() =>
             showSnackError(
               'Lorem ipsum dolor, sit amet consectetur adipisicing elit. Ad nostrum sint minus consectetur nam exercitationem eius reiciendis voluptatibus aliquam repudiandae!'
@@ -58,7 +60,7 @@ const SnackbarDocsPage: CustomNextPage = () => {
           }
         >
           Enqueue Error
-        </ButtonPrimary>
+        </Button>
       </div>
     </div>
   );

--- a/src/ui/Button/Button.tsx
+++ b/src/ui/Button/Button.tsx
@@ -1,50 +1,12 @@
 import { ComponentProps } from 'react';
 import { styled } from 'twin.macro';
-import {
-  primaryStyle,
-  secondaryStyle,
-  ghostStyle,
-  outlineStyle,
-  linkStyle,
-  BaseProps,
-} from './styles';
+import { ButtonBaseProps, styles } from './styles';
+
+export type ButtonProps = ComponentProps<'button'> & ButtonBaseProps;
 
 /**
- * Props for all the buttons in `@ui/Button`
+ * A component provides styling for a native {@link HTMLButtonElement}
  */
-export type ButtonProps = ComponentProps<'button'> & BaseProps;
-
-/**
- * Button with {@link primaryStyle}
- */
-export const ButtonPrimary = styled.button<BaseProps>`
-  ${primaryStyle}
-`;
-
-/**
- * Native {@link HTMLButtonElement} with {@link secondaryStyle}
- */
-export const ButtonSecondary = styled.button<BaseProps>`
-  ${secondaryStyle}
-`;
-
-/**
- * Native {@link HTMLButtonElement} with {@link ghostStyle}
- */
-export const ButtonGhost = styled.button<BaseProps>`
-  ${ghostStyle}
-`;
-
-/**
- * Native {@link HTMLButtonElement} with {@link outlineStyle}
- */
-export const ButtonOutline = styled.button<BaseProps>`
-  ${outlineStyle}
-`;
-
-/**
- * Native {@link HTMLButtonElement} with {@link linkStyle}
- */
-export const ButtonLink = styled.button<BaseProps>`
-  ${linkStyle}
+export const Button = styled.button<ButtonBaseProps>`
+  ${styles}
 `;

--- a/src/ui/Button/Link.tsx
+++ b/src/ui/Button/Link.tsx
@@ -1,16 +1,10 @@
 import { ComponentProps, forwardRef } from 'react';
 import NextLink, { LinkProps as NextLinkProps } from 'next/link';
-import {
-  outlineStyle,
-  ghostStyle,
-  secondaryStyle,
-  primaryStyle,
-  linkStyle,
-  BaseProps,
-} from './styles';
+import { ButtonBaseProps } from './styles';
+import { Button } from '.';
 
 export type LinkProps = ComponentProps<'a'> &
-  BaseProps & {
+  ButtonBaseProps & {
     href: string;
     nextLinkProps?: Omit<NextLinkProps, 'href'>;
   };
@@ -19,52 +13,19 @@ export type LinkProps = ComponentProps<'a'> &
  * A Link component that implements the {@link React.forwardRef} API and is capable of
  * rendering both internal links with {@link NextLink} and external links with native {@link HTMLAnchorElement}
  */
-export const LinkBase = forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ href, nextLinkProps, children, ...props }, ref) =>
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ href, nextLinkProps, ...props }, ref) =>
     href.startsWith('/') ? (
-      <NextLink href={href} {...nextLinkProps}>
-        <a {...props} ref={ref}>
-          {children}
-        </a>
+      <NextLink href={href} {...nextLinkProps} passHref>
+        <Button as="a" {...props} ref={ref} />
       </NextLink>
     ) : (
-      <a href={href} {...props} ref={ref} rel="noopener noreferrer nofollow">
-        {children}
-      </a>
+      <Button
+        as="a"
+        href={href}
+        {...props}
+        ref={ref}
+        rel="noopener noreferrer nofollow"
+      />
     )
-);
-
-/**
- * {@link LinkBase} with {@link primaryStyle}
- */
-export const LinkPrimary = forwardRef<HTMLAnchorElement, LinkProps>(
-  (props, ref) => <LinkBase css={primaryStyle} {...props} ref={ref} />
-);
-
-/**
- * {@link LinkBase} with {@link secondaryStyle}
- */
-export const LinkSecondary = forwardRef<HTMLAnchorElement, LinkProps>(
-  (props, ref) => <LinkBase css={secondaryStyle} {...props} ref={ref} />
-);
-
-/**
- * {@link LinkBase} with {@link ghostStyle}
- */
-export const LinkGhost = forwardRef<HTMLAnchorElement, LinkProps>(
-  (props, ref) => <LinkBase css={ghostStyle} {...props} ref={ref} />
-);
-
-/**
- * {@link LinkBase} with {@link outlineStyle}
- */
-export const LinkOutline = forwardRef<HTMLAnchorElement, LinkProps>(
-  (props, ref) => <LinkBase css={outlineStyle} {...props} ref={ref} />
-);
-
-/**
- * {@link LinkBase} with {@link linkStyle} (regular link appearance)
- */
-export const LinkSimple = forwardRef<HTMLAnchorElement, LinkProps>(
-  (props, ref) => <LinkBase css={linkStyle} {...props} ref={ref} />
 );

--- a/src/ui/Button/styles.ts
+++ b/src/ui/Button/styles.ts
@@ -2,6 +2,8 @@ import tw, { css } from 'twin.macro';
 
 type Size = 'lg' | 'md' | 'sm';
 
+type Variant = 'primary' | 'secondary' | 'ghost' | 'outline' | 'link';
+
 /**
  * Getter for styling of buttons and links when `icon` is `false` or not specified
  */
@@ -46,7 +48,11 @@ function getIconSizeStyle(size?: Size) {
 const getRoundedStyle = (rounded?: boolean) =>
   rounded ? tw`rounded-full` : tw`rounded`;
 
-export type BaseProps = {
+export type ButtonBaseProps = {
+  /**
+   * Appearance variant of the button
+   */
+  variant?: Variant;
   /**
    * Size of the button which can be different between regular and icon variant even at the same size
    */
@@ -64,9 +70,94 @@ export type BaseProps = {
 };
 
 /**
- * Base styles for all buttons and links in `@ui/Button`
+ * Styling for button by variants
  */
-const baseStyle = css<BaseProps>`
+const variantStyle: Record<Variant | '', ReturnType<typeof css>> = {
+  '': css``,
+
+  /**
+   * Styling for button in `primary` variant
+   */
+  primary: css`
+    ${tw`font-semibold  bg-primary text-white`}
+
+    &:hover:not(:disabled) {
+      ${tw`bg-primary-dark`}
+    }
+
+    &:active,
+    &:focus-visible {
+      ${tw`ring-4 ring-primary ring-opacity-50`}
+    }
+  `,
+
+  /**
+   * Styling for button in `secondary` variant
+   */
+  secondary: css`
+    ${tw`font-semibold  bg-secondary text-white`}
+
+    &:hover:not(:disabled) {
+      ${tw`filter brightness-90`}
+    }
+
+    &:active,
+    &:focus-visible {
+      ${tw`ring-4 ring-secondary ring-opacity-50`}
+    }
+  `,
+
+  /**
+   * Styling for button in `ghost` variant
+   */
+  ghost: css`
+    &:hover:not(:disabled) {
+      ${tw`bg-light`}
+    }
+
+    &:focus-visible,
+    &:active {
+      ${tw`ring-2 ring-dark`}
+    }
+  `,
+
+  /**
+   * Styling for button in `outline` variant
+   */
+  outline: css`
+    ${tw`border`}
+
+    &:hover:not(:disabled), &:active {
+      ${tw`bg-light`}
+    }
+
+    &:focus-visible {
+      ${tw`ring-2 ring-dark`}
+    }
+  `,
+
+  /**
+   * Styling for button to look like a link
+   */
+  link: css`
+    ${tw`underline text-secondary`}
+
+    &:hover:not(:disabled) {
+      ${tw`no-underline`}
+    }
+
+    &:focus-visible,
+    &:active {
+      ${tw`ring-2 ring-dark ring-offset-2`}
+    }
+  `,
+};
+
+/**
+ * Computed styles for all buttons and links in `@ui/Button`
+ */
+export const styles = css<ButtonBaseProps>`
+  ${(p) => variantStyle[p.variant ?? '']}
   ${(p) =>
     p.icon
       ? css`
@@ -81,91 +172,4 @@ const baseStyle = css<BaseProps>`
           ${getRoundedStyle(p.rounded)}
         `}
   ${tw`disabled:(opacity-60 cursor-not-allowed)`}
-`;
-
-/**
- * Styling for button in `primary` theme
- */
-export const primaryStyle = css`
-  ${baseStyle}
-
-  ${tw`font-semibold  bg-primary text-white`}
-
-  &:hover:not(:disabled) {
-    ${tw`bg-primary-dark`}
-  }
-
-  &:active,
-  &:focus-visible {
-    ${tw`ring-4 ring-primary ring-opacity-50`}
-  }
-`;
-
-/**
- * Styling for button in `secondary` theme
- */
-export const secondaryStyle = css`
-  ${baseStyle}
-
-  ${tw`font-semibold  bg-secondary text-white`}
-
-  &:hover:not(:disabled) {
-    ${tw`filter brightness-90`}
-  }
-
-  &:active,
-  &:focus-visible {
-    ${tw`ring-4 ring-secondary ring-opacity-50`}
-  }
-`;
-
-/**
- * Styling for button in `ghost` theme
- */
-export const ghostStyle = css`
-  ${baseStyle}
-
-  &:hover:not(:disabled) {
-    ${tw`bg-light`}
-  }
-
-  &:focus-visible,
-  &:active {
-    ${tw`ring-2 ring-dark`}
-  }
-`;
-
-/**
- * Styling for button in `outline` theme
- */
-export const outlineStyle = css`
-  ${baseStyle}
-
-  ${tw`border`}
-
-  &:hover:not(:disabled), &:active {
-    ${tw`bg-light`}
-  }
-
-  &:focus-visible {
-    ${tw`ring-2 ring-dark`}
-  }
-`;
-
-/**
- * Styling for button to look like a link
- */
-export const linkStyle = css`
-  ${baseStyle}
-
-  ${tw`underline text-secondary`}
-
-  &:hover:not(:disabled) {
-    ${tw`no-underline`}
-  }
-
-  &:focus-visible,
-  &:active {
-    ${tw`ring-2 ring-dark ring-offset-2`}
-  }
 `;

--- a/src/ui/Form/Form.tsx
+++ b/src/ui/Form/Form.tsx
@@ -1,7 +1,8 @@
 import { FormHTMLAttributes, PropsWithChildren } from 'react';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
 import tw, { css, styled } from 'twin.macro';
-import { ButtonLink } from '@ui/Button';
+import { Button } from '@ui/Button';
+import { ButtonBaseProps } from '@ui/Button/styles';
 
 type FormProps = FormHTMLAttributes<HTMLFormElement> & {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -79,7 +80,8 @@ Form.Select = styled.select`
   appearance: none;
 `;
 
-Form.ShowPasswordButton = styled(ButtonLink)`
+const showPasswordButtonAttrs: ButtonBaseProps = { variant: 'link' };
+Form.ShowPasswordButton = styled(Button).attrs(showPasswordButtonAttrs)`
   ${tw`absolute right-md top-1/2 transform -translate-y-1/2`}
   ${tw`underline text-body2`}
 `;

--- a/src/ui/HorizontalScroll/HorizontalScroll.tsx
+++ b/src/ui/HorizontalScroll/HorizontalScroll.tsx
@@ -6,7 +6,7 @@ import useOverflow from '@hooks/useOverflow';
 import { CSSProp } from 'styled-components';
 import tw from 'twin.macro';
 import { hideScrollbar } from '@styles/GlobalStyles';
-import { ButtonGhost } from '@ui/Button';
+import { Button } from '@ui/Button';
 
 type HorizontalScrollProps = {
   /**
@@ -66,9 +66,10 @@ const HorizontalScroll: FC<HorizontalScrollProps> = ({
   return (
     <div tw="flex items-center gap-xs" {...props}>
       {isOverFlowingX && (
-        <ButtonGhost
+        <Button
           icon
           size="md"
+          variant="ghost"
           tw="flex-shrink-0"
           css={getScrollButtonThemeStyle(theme)}
           style={{
@@ -78,7 +79,7 @@ const HorizontalScroll: FC<HorizontalScrollProps> = ({
         >
           <span tw="sr-only">Scroll left</span>
           <Icon icon={arrowIosBackFill} />
-        </ButtonGhost>
+        </Button>
       )}
       <div
         ref={childWrapperRef}
@@ -91,9 +92,10 @@ const HorizontalScroll: FC<HorizontalScrollProps> = ({
         {children}
       </div>
       {isOverFlowingX && (
-        <ButtonGhost
+        <Button
           icon
           size="md"
+          variant="ghost"
           tw="flex-shrink-0"
           css={getScrollButtonThemeStyle(theme)}
           style={{
@@ -103,7 +105,7 @@ const HorizontalScroll: FC<HorizontalScrollProps> = ({
         >
           <span tw="sr-only">Scroll right</span>
           <Icon icon={arrowIosForwardFill} />
-        </ButtonGhost>
+        </Button>
       )}
     </div>
   );

--- a/src/ui/LocationSearchBar/LocationSearchBar.tsx
+++ b/src/ui/LocationSearchBar/LocationSearchBar.tsx
@@ -2,7 +2,7 @@ import { Icon } from '@iconify/react';
 import searchFill from '@iconify/icons-eva/search-fill';
 import styled from 'styled-components';
 import tw from 'twin.macro';
-import { ButtonPrimary } from '@ui/Button';
+import { Button } from '@ui/Button';
 
 type Props = {
   className?: string;
@@ -12,14 +12,15 @@ const SearchBar = ({ className }: Props) => {
     <StyledWrapper className={className}>
       <StyledInput placeholder="Start your search" />
 
-      <ButtonPrimary
+      <Button
         icon
         size="md"
+        variant="primary"
         tw="absolute top-1/2 right-sm transform -translate-y-1/2"
       >
         <Icon icon={searchFill} />
         <span tw="sr-only">Search</span>
-      </ButtonPrimary>
+      </Button>
     </StyledWrapper>
   );
 };

--- a/src/ui/Menu/MenuItemBase.tsx
+++ b/src/ui/Menu/MenuItemBase.tsx
@@ -5,7 +5,7 @@ import tw, { styled } from 'twin.macro';
  * A component provides styling for items used within a `Menu`
  */
 const MenuItemBase = styled(RadixDropdownMenu.Item)`
-  ${tw`font-inherit block px-md py-sm cursor-pointer hover:bg-light`}
+  ${tw`font-inherit text-left block px-md py-sm cursor-pointer hover:bg-light`}
   ${(p) => p.disabled && tw`cursor-not-allowed hover:bg-transparent`}
 
   &:focus-visible:not(:hover) {

--- a/src/ui/Menu/MenuLink.tsx
+++ b/src/ui/Menu/MenuLink.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu';
-import { LinkBase, LinkProps } from '@ui/Button/Link';
+import { Link, LinkProps } from '@ui/Button/Link';
 import MenuItemBase from './MenuItemBase';
 import { useRouteMatch } from '@hooks/useRouteMatch';
 
@@ -18,7 +18,7 @@ const MenuLink: FC<MenuLinkProps> = ({ menuItemProps, ...props }) => {
   const matched = useRouteMatch(props.href, true);
   return (
     <MenuItemBase disabled={matched} {...menuItemProps} asChild>
-      <LinkBase {...props} />
+      <Link {...props} />
     </MenuItemBase>
   );
 };

--- a/src/ui/Modal/Modal.tsx
+++ b/src/ui/Modal/Modal.tsx
@@ -7,9 +7,9 @@ import {
   DialogOverlay as ReachDialogOverlay,
   DialogContent as ReachDialogContent,
 } from '@reach/dialog';
-import { ButtonGhost } from '@ui/Button';
 import Text from '@ui/Text/Text';
 import { AnimatePresence, motion, Transition, Variants } from 'framer-motion';
+import { Button } from '@ui/Button';
 
 type CloseModalButtonPosition = 'left' | 'right' | 'none';
 type ModalSize = 'full' | 'xl' | 'lg' | 'md' | 'sm' | 'xs';
@@ -61,14 +61,15 @@ const Modal: FC<ModalProps> = ({
           >
             {header && (
               <ModalHeader>
-                <ButtonGhost
+                <Button
                   icon
+                  variant="ghost"
                   css={closeModalBtnCss(closeButtonPosition)}
                   onClick={onClose}
                 >
                   {closeButtonIcon ?? <Icon icon={closeFill} tw="w-6 h-6" />}
                   <span tw="sr-only">Close dialog</span>
-                </ButtonGhost>
+                </Button>
                 <Text component="h3" variant="h5" id={modalTitleId}>
                   {header}
                 </Text>

--- a/src/ui/Snackbar/Snackbar.tsx
+++ b/src/ui/Snackbar/Snackbar.tsx
@@ -9,7 +9,7 @@ import checkmarkCircle2Fill from '@iconify/icons-eva/checkmark-circle-2-fill';
 import alertTriangleFill from '@iconify/icons-eva/alert-triangle-fill';
 import infoFill from '@iconify/icons-eva/info-fill';
 import Text from '@ui/Text/Text';
-import { ButtonGhost } from '@ui/Button';
+import { Button } from '@ui/Button';
 
 type Props = {
   /**
@@ -48,15 +48,16 @@ function Snackbar({ className, severity = 'default', ...props }: Props) {
 
         <Text tw="text-muted">{props.message}</Text>
       </div>
-      <ButtonGhost
+      <Button
         icon
         size="sm"
+        variant="ghost"
         onClick={props.onDismiss}
         tw="  text-muted ml-auto flex-center"
       >
         <Icon icon={closeFill} tw="w-5 h-5" />
         <span tw="sr-only">Dismiss snackbar</span>
-      </ButtonGhost>
+      </Button>
     </StyledContainer>
   );
 }


### PR DESCRIPTION
# Changelog:

* Use `variant` prop to specify theme instead of `ButtonPrimary`, `ButtonSecondary`... etc. (The reason I went with `variant` instead of `theme` is that `theme` is a reserved prop in `styled-component`).
* Use `Button` as a polymorphic component for `Link` with the `as` prop.